### PR TITLE
autotarget for everyone

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -45,6 +45,8 @@
 #include "../utils/petutils.h"
 #include "../utils/puppetutils.h"
 #include "../weapon_skill.h"
+#include "../entities/mobentity.h"
+#include "../enmity_container.h"
 
 CBattleEntity::CBattleEntity()
 {
@@ -524,6 +526,20 @@ int32 CBattleEntity::addHP(int32 hp)
     if (health.hp == 0 && m_unkillable)
     {
         health.hp = 1;
+    }
+
+    // if dead mob, autotarget
+    if (health.hp == 0 && objtype == TYPE_MOB) {
+        auto PTargetList = (static_cast<CMobEntity*>(this))->PEnmityContainer->GetEnmityList();
+        for (const auto& Element : *PTargetList)
+        {
+            auto PEntity = Element.second.PEnmityOwner;
+            // ShowDebug("trying autotarget PEnt->Bat: %d  this: %d \n", (int)PEntity->GetBattleTarget(), (int)this);
+            if (PEntity->objtype == TYPE_PC && PEntity->GetBattleTarget() == this)
+            {
+                static_cast<CCharEntity*>(PEntity)->AutoTarget();
+            }
+        }
     }
 
     return abs(hp);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -665,6 +665,30 @@ void CCharEntity::OnDisengage(CAttackState& state)
     PLatentEffectContainer->CheckLatentsWeaponDraw(false);
 }
 
+/* call this when the mob I'm engaged on dies */
+void CCharEntity::AutoTarget()
+{
+    if (this->m_hasAutoTarget)
+    {
+        for (auto&& PPotentialTarget : this->SpawnMOBList)
+        {
+            if (PPotentialTarget.second->animation == ANIMATION_ATTACK &&
+                facing(this->loc.p, PPotentialTarget.second->loc.p, 72) &&
+                distanceSquared(this->loc.p, PPotentialTarget.second->loc.p) <= 400)
+            {
+                std::unique_ptr<CBasicPacket> errMsg;
+                if (IsValidTarget(PPotentialTarget.second->targid, TARGET_ENEMY, errMsg))
+                {
+                    // ShowDebug("found valid autotarget, changing target\n");
+                    auto controller{ static_cast<CPlayerController*>(PAI->GetController()) };
+                    controller->ChangeTarget(PPotentialTarget.second->targid);
+                    return;
+                }
+            }
+        }
+    }
+}
+
 bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
 {
     float dist = distance(loc.p, PTarget->loc.p);
@@ -700,28 +724,6 @@ bool CCharEntity::OnAttack(CAttackState& state, action_t& action)
     auto controller {static_cast<CPlayerController*>(PAI->GetController())};
     controller->setLastAttackTime(server_clock::now());
     auto ret = CBattleEntity::OnAttack(state, action);
-
-    auto PTarget = static_cast<CBattleEntity*>(state.GetTarget());
-
-    if (PTarget->isDead())
-    {
-        if (this->m_hasAutoTarget && PTarget->objtype == TYPE_MOB) // Auto-Target
-        {
-            for (auto&& PPotentialTarget : this->SpawnMOBList)
-            {
-                if (PPotentialTarget.second->animation == ANIMATION_ATTACK &&
-                    facing(this->loc.p, PPotentialTarget.second->loc.p, 64) &&
-                    distance(this->loc.p, PPotentialTarget.second->loc.p) <= 10)
-                {
-                    std::unique_ptr<CBasicPacket> errMsg;
-                    if (IsValidTarget(PPotentialTarget.second->targid, TARGET_ENEMY, errMsg))
-                    {
-                        controller->ChangeTarget(PPotentialTarget.second->targid);
-                    }
-                }
-            }
-        }
-    }
     return ret;
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -367,6 +367,9 @@ public:
     bool hasMoghancement(uint16 moghancementID);
     void UpdateMoghancement();
 
+    /* call this when the mob I'm engaged on dies */
+    void AutoTarget();
+
     /* State callbacks */
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
     virtual bool OnAttack(CAttackState&, action_t&) override;


### PR DESCRIPTION
fixes a bug where autotarget only works for the 1 player that gets the last hit
With this, autotarget works for everyone engaged, as it should.