### PR TITLE
fix acc varies with tp weaponskills

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -501,7 +501,6 @@ function souleaterBonus(attacker, numhits)
 end
 
 function accVariesWithTP(hitrate, acc, tp, a1, a2, a3)
-    -- sadly acc varies with tp ALL apply an acc PENALTY, the acc at various %s are given as a1 a2 a3
     accpct = fTP(tp, a1, a2, a3)
     acclost = acc - (acc*accpct)
     hrate = hitrate - (0.005*acclost)

--- a/scripts/globals/weaponskills/asuran_fists.lua
+++ b/scripts/globals/weaponskills/asuran_fists.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.1 params.dex_wsc = 0.0 params.vit_wsc = 0.1 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -29,7 +29,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.1 params.dex_wsc = 0.1 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1.0
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/blast_arrow.lua
+++ b/scripts/globals/weaponskills/blast_arrow.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/blast_shot.lua
+++ b/scripts/globals/weaponskills/blast_shot.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/dancing_edge.lua
+++ b/scripts/globals/weaponskills/dancing_edge.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/decimation.lua
+++ b/scripts/globals/weaponskills/decimation.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/penta_thrust.lua
+++ b/scripts/globals/weaponskills/penta_thrust.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 0.875; params.atk200 = 0.875; params.atk300 = 0.875
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/realmrazer.lua
+++ b/scripts/globals/weaponskills/realmrazer.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.85 + (player:getMerit(tpz.merit.REALMRAZER) / 100) params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/ruinator.lua
+++ b/scripts/globals/weaponskills/ruinator.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.85 + (player:getMerit(tpz.merit.RUINATOR) / 100) params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1.0
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1.1; params.atk200 = 1.1; params.atk300 = 1.1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/swift_blade.lua
+++ b/scripts/globals/weaponskills/swift_blade.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 1 params.acc200= 1.1 params.acc300= 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/tachi_rana.lua
+++ b/scripts/globals/weaponskills/tachi_rana.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1
+    params.acc100 = 1 params.acc200 = 1.1 params.acc300 = 1.2
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then


### PR DESCRIPTION
Someone thought that "Accuracy varies with TP" always means you lose accuracy with 1000 TP.
I've looked for evidence of this and haven't found any.
It should only be an accuracy bonus for higher TP.

There are well known weaponskills with accuracy penalties, like Slug Shot, Sidewinder, True Strike.
This does not change those.