### PR TITLE
zone spawn fix

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -851,7 +851,8 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
 
         CCharEntity* PChar = map_session_data->PChar;
 
-        if ((time(nullptr) - map_session_data->last_update) > 5)
+        time_t now = time(nullptr);
+        if ((now - map_session_data->last_update) > 5)
         {
             if (PChar != nullptr && !(PChar->nameflags.flags & FLAG_DC))
             {
@@ -863,7 +864,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     PChar->loc.zone->SpawnPCs(PChar);
                 }
             }
-            if ((time(nullptr) - map_session_data->last_update) > map_config.max_time_lastupdate)
+            if ((now - map_session_data->last_update) > map_config.max_time_lastupdate)
             {
                 if (PChar != nullptr)
                 {
@@ -941,6 +942,13 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                 PChar->loc.zone->SpawnPCs(PChar);
             }
             charutils::SaveCharStats(PChar);
+        }
+        // recent update and not FLAG_DC
+        else if (PChar != nullptr && (now - PChar->GetLocalVar("ZoneInTime") < 11)) {
+            // this is to fix the bug of a player spawn packet getting lost when zoning
+            // for a few seconds after you zone, it forces a few spawn packets
+            // ShowDebug("ZoneInTime: " + std::to_string(PChar->GetLocalVar("ZoneInTime")) + "  - now: " + std::to_string(now) + "\n");
+            PChar->loc.zone->SpawnPCs(PChar, true);
         }
         ++it;
     }

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -681,9 +681,9 @@ void CZone::SpawnNPCs(CCharEntity* PChar)
 *                                                                       *
 ************************************************************************/
 
-void CZone::SpawnPCs(CCharEntity* PChar)
+void CZone::SpawnPCs(CCharEntity* PChar, bool force)
 {
-    m_zoneEntities->SpawnPCs(PChar);
+    m_zoneEntities->SpawnPCs(PChar, force);
 }
 
 /************************************************************************

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -551,7 +551,7 @@ public:
     void            SetWeather(WEATHER weatherCondition);
     void            UpdateWeather();
 
-    virtual void    SpawnPCs(CCharEntity* PChar);                                   // отображаем персонажей в зоне
+    virtual void    SpawnPCs(CCharEntity* PChar, bool force=false);                 // отображаем персонажей в зоне
     virtual void    SpawnMOBs(CCharEntity* PChar);                                  // отображаем MOBs в зоне
     virtual void    SpawnPETs(CCharEntity* PChar);                                  // отображаем PETs в зоне
     virtual void    SpawnNPCs(CCharEntity* PChar);                                  // отображаем NPCs в зоне

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -494,7 +494,7 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
     }
 }
 
-void CZoneEntities::SpawnPCs(CCharEntity* PChar)
+void CZoneEntities::SpawnPCs(CCharEntity* PChar, bool force)
 {
     TracyZoneScoped;
     for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
@@ -506,7 +506,7 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
         {
             if (distance(PChar->loc.p, PCurrentChar->loc.p) < 50 && PChar->m_moghouseID == PCurrentChar->m_moghouseID)
             {
-                if (PC == PChar->SpawnPCList.end())
+                if (force || (PC == PChar->SpawnPCList.end()))
                 {
                     if (PCurrentChar->m_isGMHidden == false)
                     {

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -34,7 +34,7 @@ public:
     CCharEntity*	GetCharByID(uint32 id);
     CBaseEntity*	GetEntity(uint16 targid, uint8 filter = -1); 					// получаем указатель на любую сущность в зоне
 
-    void			SpawnPCs(CCharEntity* PChar);									// отображаем персонажей в зоне
+    void			SpawnPCs(CCharEntity* PChar, bool force=false);					// отображаем персонажей в зоне
     void			SpawnMOBs(CCharEntity* PChar);									// отображаем MOBs в зоне
     void			SpawnPETs(CCharEntity* PChar);									// отображаем PETs в зоне
     void			SpawnNPCs(CCharEntity* PChar);									// отображаем NPCs в зоне

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -249,11 +249,11 @@ void CZoneInstance::SpawnNPCs(CCharEntity* PChar)
     }
 }
 
-void CZoneInstance::SpawnPCs(CCharEntity* PChar)
+void CZoneInstance::SpawnPCs(CCharEntity* PChar, bool force)
 {
     if (PChar->PInstance)
     {
-        PChar->PInstance->SpawnPCs(PChar);
+        PChar->PInstance->SpawnPCs(PChar, force);
     }
 }
 

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -35,7 +35,7 @@ public:
     virtual CCharEntity*	GetCharByID(uint32 id) override;
     virtual CBaseEntity*	GetEntity(uint16 targid, uint8 filter = -1) override; 			// получаем указатель на любую сущность в зоне
 
-    virtual void	SpawnPCs(CCharEntity* PChar) override; 									// отображаем персонажей в зоне
+    virtual void	SpawnPCs(CCharEntity* PChar, bool force=false) override; 				// отображаем персонажей в зоне
     virtual void	SpawnMOBs(CCharEntity* PChar) override;									// отображаем MOBs в зоне
     virtual void	SpawnPETs(CCharEntity* PChar) override;									// отображаем PETs в зоне
     virtual void	SpawnNPCs(CCharEntity* PChar) override;									// отображаем NPCs в зоне


### PR DESCRIPTION
This is to fix the issue when 2 players zone close to the same time,
(one dual-box character following the other)
the spawn packets sometimes get lost and the 2 characters can't see each other.

After you zone it sends a few extra spawn packets for a few seconds.