### PR TITLE
zeruhn gate workarounds

### DIFF
--- a/scripts/zones/Palborough_Mines/npcs/_3z2.lua
+++ b/scripts/zones/Palborough_Mines/npcs/_3z2.lua
@@ -1,13 +1,17 @@
 -----------------------------------
 -- Area: Palborough Mines
---  NPC: Old Toolbox
--- Continues Quest: The Eleventh's Hour (100%)
+--  NPC: Dock Lever
+-- zone to Zeruhn Mines
 -----------------------------------
 
 function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
+    -- TODO: confirm this is the correct cutscene
+    -- cutscene should show boat going down the river
+    -- (it's not correct in the client versions that I have
+    -- it might be correct in some other version)
     player:startEvent(14)
 end
 

--- a/scripts/zones/Zeruhn_Mines/Zone.lua
+++ b/scripts/zones/Zeruhn_Mines/Zone.lua
@@ -29,6 +29,10 @@ function onZoneIn(player, prevZone)
             if not player:hasItem(16607) then
                 cs = 131
             end
+        else
+            print("Zeruhn Mines workaround until we figure out how to work cutscene 150")
+            player:setPos(-73, 0, 60)
+            return -1
         end
     elseif player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(-270.707, 14.159, -20.268, 0)
@@ -45,6 +49,10 @@ function onRegionEnter(player, region)
 end
 
 function onEventUpdate(player, csid, option)
+    if csid == 150 then
+        print("Zeruhn_Mines onEventUpdate csid: " .. csid)
+        -- I think this is where we need to send a packet to open gate, or something.
+    end
 end
 
 function onEventFinish(player, csid, option)

--- a/scripts/zones/Zeruhn_Mines/npcs/Lasthenes.lua
+++ b/scripts/zones/Zeruhn_Mines/npcs/Lasthenes.lua
@@ -8,6 +8,8 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
+    -- workaround until we figure out how to open gate
+    player:setLocalVar("KorrolokaGate", 0)
     if player:getXPos() > -79.5 then
         player:startEvent(180)
     else
@@ -16,7 +18,16 @@ function onTrigger(player, npc)
 end
 
 function onEventUpdate(player, csid, option)
+    print("figure out how to open Zeruhn Mines gates")
+    player:setLocalVar("KorrolokaGate", 1)
 end
 
 function onEventFinish(player, csid, option)
+    if player:getLocalVar("KorrolokaGate") == 1 then
+        if csid == 180 then
+            player:setPos(-82, 0, 20, 128)
+        elseif csid == 181 then
+            player:setPos(-78, 0, 20, 0)
+        end
+    end
 end


### PR DESCRIPTION
workarounds for the 2 gate bugs in Zeruhn Mines

For the Palborough zone, the workaround just skips the gate cutscene. If a player gets into that cutscene, they will get stuck and need a GM to move them to a different zone.

For the Korroloka gate, the cutscene doesn't get stuck, but the player can't get through the gate. So the workaround just uses a local variable to know whether to teleport the player through the gate.

There's probably some packet we need to send to open the gates in `onEventUpdate`.