### PR TITLE
fix spirit bond crash

### DIFF
--- a/scripts/globals/abilities/spirit_bond.lua
+++ b/scripts/globals/abilities/spirit_bond.lua
@@ -14,5 +14,5 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
-    player:addStatusEffect(tpz.effect.SPIRIT_BOND, 14, 0, 60)
+    -- player:addStatusEffect(tpz.effect.SPIRIT_BOND, 14, 0, 60) -- TODO: implement tpz.effect.SPIRIT_BOND
 end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -773,6 +773,8 @@ tpz.effect =
     MAGIC_EVASION_BOOST_II   = 611,
     COLURE_ACTIVE            = 612,
 
+    SPIRIT_BOND              = 619,
+
     RAMPART                  = 623,
     -- Effect icons in packet can go from 0-767, so no custom effects should go in that range.
 


### PR DESCRIPTION
This fixes crash when using Spirit Bond.

Note: Spirit Bond is not implemented, even in the latest LSB.